### PR TITLE
Improve Get-MCStats reliability

### DIFF
--- a/Get-MCStats.ps1
+++ b/Get-MCStats.ps1
@@ -73,6 +73,7 @@ function Send-RconCommand {
         [string]$password,
         [string]$command
     )
+    $client = $null
     try {
         $client = New-Object System.Net.Sockets.TcpClient
         $client.Connect($serverHost, $serverPort)
@@ -148,12 +149,14 @@ function Send-RconCommand {
                 $commandResponse += "`n" + $packet.Payload
             }
         }
-        $client.Close()
         return $commandResponse
     }
     catch {
         Write-Log "Error during RCON communication: ${_}"
         throw $_
+    }
+    finally {
+        if ($client) { $client.Close() }
     }
 }
 
@@ -239,7 +242,7 @@ Get-ChildItem -Path $statsFolder -Filter *.json | Where-Object { $ignoreFiles -n
         Write-Log "Successfully read JSON file: $filePath"
     } catch {
         Write-Log "Error reading file ${filePath}: ${_}"
-        return
+        continue
     }
     
     # Resolve player name from Mojang API.


### PR DESCRIPTION
## Summary
- prevent early script exit when reading corrupted player stats
- close the RCON connection in a finally block

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f622586e8832eab004bde5e5d46a1